### PR TITLE
🤖 Merge into triage: refs/heads/46-add-a-way-to-upload-own-images-for-avatar

### DIFF
--- a/.github/workflows/pullrequest_to_master.yml
+++ b/.github/workflows/pullrequest_to_master.yml
@@ -2,8 +2,7 @@ name:  🔀 Pull request
 
 on:
   push:
-    branches:
-      - 'triage'
+    branches: [ "triage" ]
 
 jobs:
   pull-request:


### PR DESCRIPTION
This PR is opened automatically on code commit. Add more code or merge. If you merge the version will be deployed to https://triage.mapmaker.nl. These lines of code changed: https://github.com/mapmaker-workshop-tools/mapmaker-platform/commit/a10bc049f716b9f23a26ce438aec8592ee7cdde9.