### PR TITLE
🤖 Merge into triage: refs/heads/redisandcelery

### DIFF
--- a/.github/workflows/Triagedeploy.yml
+++ b/.github/workflows/Triagedeploy.yml
@@ -34,7 +34,7 @@ jobs:
     # Containers must run in Linux based operating systems
     runs-on: ubuntu-latest
     # Docker Hub image that `container-job` executes in
-    container: python:3.9-buster
+    container: python:3.11-buster
 
     # Service containers to run with `container-job`
     services:


### PR DESCRIPTION
This PR is opened automatically on code commit. Add more code or merge. If you merge the version will be deployed to https://triage.mapmaker.nl. These lines of code changed: https://github.com/mapmaker-workshop-tools/mapmaker-platform/commit/5381bc03defcbd5b7502b1aaa70a9b7bf9787e04.