### PR TITLE
🤖 Merge into triage: refs/heads/keep-proportions-image

### DIFF
--- a/Infrastructure/requirements.txt
+++ b/Infrastructure/requirements.txt
@@ -24,4 +24,4 @@ Celery
 django-celery-beat 
 django-celery-results
 python-decouple
-
+redis


### PR DESCRIPTION
This PR is opened automatically on code commit. Add more code or merge. If you merge the version will be deployed to https://triage.mapmaker.nl. These lines of code changed: https://github.com/mapmaker-workshop-tools/mapmaker-platform/commit/43f1d87d2f1375c045817f2f18091417683b6afc.